### PR TITLE
Log import error for unified architecture patch

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -51,8 +51,10 @@ from src.utils.threading_utils import start_background_task
 # Import the new unified cognitive architecture
 try:
     from src.core.unified_master_cognitive_architecture_fix import patch_unified_architecture
-except:
-    pass
+except ImportError as e:
+    logging.getLogger(__name__).error(
+        f"Failed to import patch_unified_architecture: {e}", exc_info=e
+    )
 
 try:
     from src.core.unified_master_cognitive_architecture import (


### PR DESCRIPTION
## Summary
- Log details when `patch_unified_architecture` import fails to aid debugging

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'coinbase')*


------
https://chatgpt.com/codex/tasks/task_e_688e3aa29d3483279220d9e783ba3752