### PR TITLE
Use timezone-aware timestamps in routers

### DIFF
--- a/src/api/routers/gpu_router.py
+++ b/src/api/routers/gpu_router.py
@@ -11,7 +11,7 @@ from fastapi.responses import JSONResponse
 from typing import Dict, List, Any, Optional
 import asyncio
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 # GPU system imports
 from src.core.gpu.gpu_manager import get_gpu_manager, is_gpu_available
@@ -31,7 +31,7 @@ async def get_gpu_status() -> Dict[str, Any]:
         
         return {
             "success": True,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "gpu_system": system_status,
             "gpu_available": is_gpu_available()
         }
@@ -48,7 +48,7 @@ async def get_gpu_performance() -> Dict[str, Any]:
         
         return {
             "success": True,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "performance": performance
         }
     except Exception as e:
@@ -64,7 +64,7 @@ async def optimize_gpu_performance() -> Dict[str, Any]:
         
         return {
             "success": True,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "optimization": optimization_result
         }
     except Exception as e:
@@ -80,7 +80,7 @@ async def clear_gpu_cache() -> Dict[str, Any]:
         
         return {
             "success": True,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "message": "GPU cache cleared successfully"
         }
     except Exception as e:
@@ -99,7 +99,7 @@ async def list_gpu_devices() -> Dict[str, Any]:
         
         return {
             "success": True,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "device_count": len(devices),
             "devices": devices,
             "current_device": gpu_manager.get_device_info()
@@ -118,7 +118,7 @@ async def switch_gpu_device(device_id: int) -> Dict[str, Any]:
         if success:
             return {
                 "success": True,
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
                 "message": f"Switched to GPU device {device_id}",
                 "current_device": gpu_manager.get_device_info()
             }
@@ -150,7 +150,7 @@ async def submit_gpu_processing_task(
         
         return {
             "success": True,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "task_id": task_id,
             "workload_type": workload_type,
             "priority": priority
@@ -169,7 +169,7 @@ async def get_gpu_workload_types() -> Dict[str, Any]:
         
         return {
             "success": True,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "workload_types": workload_types,
             "descriptions": {
                 "geoid_processing": "Process batches of geoids with GPU acceleration",
@@ -235,7 +235,7 @@ async def run_gpu_benchmarks() -> Dict[str, Any]:
         
         return {
             "success": True,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "benchmarks": results,
             "gpu_info": get_gpu_manager().get_device_info()
         }
@@ -295,7 +295,7 @@ async def gpu_health_check() -> Dict[str, Any]:
         
         return {
             "success": True,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "overall_health": overall_health,
             "details": health_status
         }
@@ -306,4 +306,4 @@ async def gpu_health_check() -> Dict[str, Any]:
 
 # Add router description
 router.tags = ["GPU Acceleration"]
-router.prefix = "/gpu" 
+router.prefix = "/gpu"

--- a/src/api/routers/system_router.py
+++ b/src/api/routers/system_router.py
@@ -9,7 +9,7 @@ status, health, and performance metrics of the KIMERA system.
 import logging
 from fastapi import APIRouter, HTTPException, Request, Response
 from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, Any
 import threading
 
@@ -43,7 +43,7 @@ async def get_system_status():
         
         return {
             "status": "operational",
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "system_state": kimera_system._state,
             "components": {
                 "vault_manager": vault_manager is not None,
@@ -70,7 +70,7 @@ async def get_system_status():
         return {
             "status": "error",
             "error": str(e),
-            "timestamp": datetime.now().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         }
 
 @router.get("/contradiction_engine")
@@ -320,7 +320,7 @@ async def get_system_state(request: Request) -> Dict[str, Any]:
             errors['metrics_instance_id'] = str(e) + "\n" + format_exc()
             logger.error(f"metrics_instance_id error: {e}", exc_info=True)
         report = {
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "system_state": system_state,
             "is_operational": is_operational,
             "is_shutdown": is_shutdown,
@@ -339,7 +339,7 @@ async def get_system_state(request: Request) -> Dict[str, Any]:
             "status": "critical_error",
             "error": str(e),
             "trace": format_exc(),
-            "timestamp": datetime.now().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         }
 
 @router.post("/system/shutdown", summary="Gracefully shut down the Kimera system", tags=["System"])
@@ -381,16 +381,16 @@ async def debug_singleton():
             "kimera_singleton_is_none": kimera_singleton is None,
             "has_attr_state": hasattr(kimera_singleton, '_state') if kimera_singleton else False,
             "has_attr_is_operational": hasattr(kimera_singleton, 'is_operational') if kimera_singleton else False,
-            "timestamp": datetime.now().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         }
     except Exception as e:
         return {
             "error": str(e),
             "trace": format_exc(),
-            "timestamp": datetime.now().isoformat()
+            "timestamp": datetime.now(timezone.utc).isoformat()
         } 
 
 @router.get("/system/ping", tags=["System"])
 async def ping():
     """Minimal endpoint to confirm FastAPI app and router health."""
-    return {"status": "ok", "message": "Kimera API is alive", "timestamp": datetime.now().isoformat()} 
+    return {"status": "ok", "message": "Kimera API is alive", "timestamp": datetime.now(timezone.utc).isoformat()}


### PR DESCRIPTION
### **User description**
## Summary
- make GPU router return timestamps using `datetime.now(timezone.utc)`
- update system router to use timezone-aware timestamps as well

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and other missing dependencies, 43 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688e4a0b0dc48327841cc07fa74693b4


___

### **PR Type**
Enhancement


___

### **Description**
- Replace `datetime.utcnow()` with timezone-aware `datetime.now(timezone.utc)`

- Update timestamp generation across GPU and system routers

- Ensure consistent UTC timezone handling in API responses


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["datetime.utcnow()"] -- "replace with" --> B["datetime.now(timezone.utc)"]
  B --> C["GPU Router Endpoints"]
  B --> D["System Router Endpoints"]
  C --> E["Timezone-aware Timestamps"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gpu_router.py</strong><dd><code>Update GPU router timestamps to timezone-aware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/api/routers/gpu_router.py

<ul><li>Import <code>timezone</code> from datetime module<br> <li> Replace 10 instances of <code>datetime.utcnow()</code> with <br><code>datetime.now(timezone.utc)</code><br> <li> Update timestamp generation in all GPU endpoint responses</ul>


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/KIMERA_SWM_System/pull/7/files#diff-bdc53c3203fb5eda8172fe9cae261f881fc24865204742f373ac489d22ff7105">+12/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>system_router.py</strong><dd><code>Update system router timestamps to timezone-aware</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/api/routers/system_router.py

<ul><li>Import <code>timezone</code> from datetime module<br> <li> Replace 6 instances of <code>datetime.now()</code> with <code>datetime.now(timezone.utc)</code><br> <li> Update timestamp generation in system status and diagnostic endpoints</ul>


</details>


  </td>
  <td><a href="https://github.com/IdirBenSlama/KIMERA_SWM_System/pull/7/files#diff-83b3ae8cfbe3641c2f3402e6d60d37be736eb128a0ff2e01a92376aa12e6033a">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

