### PR TITLE
Replace SQLite with Postgres stack and enforce GPU

### DIFF
--- a/configs/database/database_config.json
+++ b/configs/database/database_config.json
@@ -1,10 +1,15 @@
 {
-  "sqlite": {
-    "path": "C:\\Users\\bensl\\Documents\\KIMERA\\Kimera-SWM\\data\\database\\kimera.db",
-    "timeout": 30,
-    "check_same_thread": false
+  "postgresql": {
+    "connection_string": "postgresql://kimera:kimera_secure_pass_2025@localhost:5432/kimera_swm",
+    "pool_size": 10,
+    "max_overflow": 20
   },
-  "connection_string": "sqlite:///C:\\Users\\bensl\\Documents\\KIMERA\\Kimera-SWM\\data\\database\\kimera.db",
-  "pool_size": 10,
-  "max_overflow": 20
+  "redis": {
+    "url": "redis://:kimera_cache_pass_2025@localhost:6379/0"
+  },
+  "neo4j": {
+    "uri": "bolt://localhost:7687",
+    "user": "neo4j",
+    "password": "kimera_graph_pass_2025"
+  }
 }

--- a/configs/database/database_config.txt
+++ b/configs/database/database_config.txt
@@ -25,9 +25,6 @@ NEO4J_PASSWORD=kimera_graph_pass_2025
 # Redis (Caching & Message Queue)
 REDIS_URL=redis://:kimera_cache_pass_2025@localhost:6379/0
 
-# SQLite Fallback
-SQLITE_DATABASE_URL=sqlite:///./data/database/kimera_swm.db
-
 # =============================================================================
 # GPU CONFIGURATION
 # =============================================================================

--- a/configs/environments/independent_production.yaml
+++ b/configs/environments/independent_production.yaml
@@ -58,8 +58,8 @@ database:
   relational:
     sqlalchemy: ">=2.0.30"
     alembic: ">=1.16.0"
-    aiosqlite: ">=0.19.0"
     psycopg2-binary: ">=2.9.9"
+    asyncpg: ">=0.30.0"
   
   graph:
     neo4j: ">=5.28.0"

--- a/configs/pyproject.toml
+++ b/configs/pyproject.toml
@@ -12,8 +12,8 @@ pydantic = "^2.11"
 pydantic-settings = "^2.1.0"
 redis = "^5.0.1"
 sqlalchemy = "^2.0.25"
-aiosqlite = "^0.19.0"
 psycopg2-binary = "^2.9.9"
+asyncpg = "^0.30.0"
 python-jose = {extras = ["cryptography"], version = "^3.3.0"}
 passlib = {extras = ["bcrypt"], version = "^1.7.4"}
 prometheus-client = "^0.19.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # KIMERA SWM Main Requirements File
 # Use independent production requirements for optimal dependency resolution
 -r requirements/independent_production.txt
+

--- a/requirements/independent_production.txt
+++ b/requirements/independent_production.txt
@@ -45,8 +45,8 @@ qiskit-ibm-runtime<=0.29
 # ===== DATABASE & STORAGE =====
 sqlalchemy>=2.0.30
 alembic>=1.16.0
-aiosqlite>=0.19.0
 psycopg2-binary>=2.9.9
+asyncpg>=0.30.0
 neo4j>=5.28.0
 networkx>=3.0
 redis>=5.0.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,7 +8,6 @@ aiohttp-retry==2.9.1
 aiolimiter==1.2.1
 aioredis==2.0.1
 aiosignal==1.3.2
-aiosqlite==0.21.0
 alembic==1.16.2
 allora_sdk==0.2.3
 alpha_vantage==3.0.0

--- a/requirements_consolidated/requirements.txt
+++ b/requirements_consolidated/requirements.txt
@@ -12,7 +12,6 @@ aiohttp-retry==2.9.1
 aiolimiter==1.2.1
 aioredis==2.0.1  # For caching and rate limiting
 aiosignal==1.3.2
-aiosqlite==0.21.0
 alembic==1.16.2
 allora-sdk==0.2.3
 alpha-vantage==3.0.0

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -35,17 +35,10 @@ class LogLevel(str, Enum):
 class DatabaseSettings(BaseSettings):
     """Database configuration settings"""
     url: str = Field(
-        default="sqlite:///kimera_swm.db",
+        default="postgresql+psycopg2://kimera:kimera_secure_pass_2025@localhost:5432/kimera_swm",
         env="KIMERA_DATABASE_URL",
-        description="Database connection URL"
+        description="Database connection URL",
     )
-    
-    # Override for testing environment
-    def __init__(self, **data):
-        # Check if we're in a test environment
-        if "pytest" in sys.modules or os.getenv("KIMERA_ENV") == "testing":
-            data.setdefault("url", "sqlite+aiosqlite:///:memory:")
-        super().__init__(**data)
     
     pool_size: int = Field(
         default=20,


### PR DESCRIPTION
## Summary
- enforce GPU availability by removing CPU fallback and requiring GPU components
- migrate configuration and dependencies from SQLite to PostgreSQL/Redis/Neo4j with updated requirement files
- streamline database connection manager to drop SQLite fallback and use credential or env-based PostgreSQL

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'coinbase')*

------
https://chatgpt.com/codex/tasks/task_e_688e38044c408327b7200780cc329a69